### PR TITLE
fix keyboard hiding card on editing titles #172

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, KeyboardEvent } from 'react-native';
+
+export const useKeyboard = (): [number] => {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  function onKeyboardDidShow(e: KeyboardEvent): void {
+    setKeyboardHeight(e.endCoordinates.height);
+  }
+
+  function onKeyboardDidHide(): void {
+    setKeyboardHeight(0);
+  }
+
+  useEffect(() => {
+    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
+    Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
+    return (): void => {
+      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
+      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
+    };
+  }, []);
+
+  return [keyboardHeight];
+};

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Keyboard, KeyboardEvent } from 'react-native';
 
-export const useKeyboard = (): [number] => {
+export const useKeyboard = (): { keyboardHeight: number } => {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   function onKeyboardDidShow(e: KeyboardEvent): void {
@@ -21,5 +21,5 @@ export const useKeyboard = (): [number] => {
     };
   }, []);
 
-  return [keyboardHeight];
+  return { keyboardHeight };
 };

--- a/src/screens/Home/DecksList/index.tsx
+++ b/src/screens/Home/DecksList/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useRef } from 'react';
-import { StyleSheet, View, Animated } from 'react-native';
+import { Animated, StyleSheet, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { SharedElement } from 'react-navigation-shared-element';
 import * as R from 'ramda';
@@ -11,6 +11,7 @@ import AddButton from '../../../common/AddButton';
 import { theme } from '../../../utils';
 import IconButton from '../../../common/IconButton';
 import NoContentInfo from '../../../common/NoContentInfo';
+import { useKeyboard } from "../../../hooks/useKeyboard";
 
 // const colors = ['#e1d1a6', '#fc9d9a', '#f9cdad', '#d6e1c7', '#94c7b6', '#c9e4d3', '#d9dbed'];
 const colors = theme.colors.list;
@@ -22,6 +23,8 @@ const DecksList: FC = () => {
   });
   const { navigate } = useNavigation();
   const { decks, decksIds, handleRemoveDeck } = useDecks();
+  const [keyboardHeight] = useKeyboard();
+
 
   const handleOpenModal = () => navigate(Screens.ADD_DECK);
 
@@ -62,7 +65,7 @@ const DecksList: FC = () => {
       ) : (
         <>
           <Animated.FlatList
-            contentContainerStyle={styles.flatListContainer}
+            contentContainerStyle={[styles.flatListContainer, { paddingBottom: keyboardHeight }]}
             scrollEventThrottle={16}
             data={decksIds}
             renderItem={renderItem}

--- a/src/screens/Home/DecksList/index.tsx
+++ b/src/screens/Home/DecksList/index.tsx
@@ -23,7 +23,7 @@ const DecksList: FC = () => {
   });
   const { navigate } = useNavigation();
   const { decks, decksIds, handleRemoveDeck } = useDecks();
-  const [keyboardHeight] = useKeyboard();
+  const { keyboardHeight } = useKeyboard();
 
 
   const handleOpenModal = () => navigate(Screens.ADD_DECK);


### PR DESCRIPTION
I went for a simple solution of adding padding to the bottom of the FlatList when the keyboard is open. So you need to manually scroll. But it is a simpler solution than using `KeyboardAvoidingView` and more stable.

If you want `KeyboardAvoidingView` I could revisit the PR. I am not reproducing the other issue.

![Simulator Screen Shot - iPhone 8 - 2021-04-12 at 22 58 59](https://user-images.githubusercontent.com/5861100/114468131-e9103600-9be2-11eb-968c-0cfe6651e9ca.png)
![Screenshot_1618272276](https://user-images.githubusercontent.com/5861100/114477563-452f8600-9bf4-11eb-8813-95a20e215fe1.png)
